### PR TITLE
package the LICENSE file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README*
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
Include the LICENSE file in `sdist` and wheels for the package. This makes it easier for redistributors/etc to satisfy the terms of your license.